### PR TITLE
add-raw-pixel-buffer-to-image: skia impl

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,4 @@
 [submodule "lib/infra"]
 	path = lib/infra
 	url = https://github.com/cycfi/infra
+	branch = master

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -157,5 +157,5 @@ add_example(space)
 add_example(composite_ops)
 add_example(paths)
 add_example(shadow)
-
+add_example(image_pixmap_chessboard)
 

--- a/examples/image_pixmap_chessboard.cpp
+++ b/examples/image_pixmap_chessboard.cpp
@@ -1,0 +1,70 @@
+/*=============================================================================
+   Copyright (c) 2016-2020 Joel de Guzman
+
+   Distributed under the MIT License (https://opensource.org/licenses/MIT)
+=============================================================================*/
+#include "app.hpp"
+
+using namespace cycfi::artist;
+
+bool constexpr is_little_endian() {
+   union {
+      uint32_t i;
+      char c[4];
+   } cmp = {0x01020304};
+   return !(cmp.c[0] == 1);
+}
+
+int constexpr rows = 8;
+int constexpr cols = 8;
+int constexpr square_side = 100;
+int constexpr square_area = square_side * square_side;
+int constexpr width = cols * square_side;
+int constexpr height = rows * square_side;
+size_t constexpr pix_buf_size = rows * cols * square_area;
+
+uint32_t constexpr white = 0xffffffff;
+// on little endian systems RGBA is formatted as ABGR for values
+std::function<uint32_t()> black = []() { return is_little_endian() ? 0xff000000 : 0x000000ff; };
+
+auto constexpr window_size = extent{
+   static_cast<float>(cols * square_side),
+   static_cast<float>(rows * square_side)
+};
+
+void draw(canvas& cnv)
+{
+   // Create a chess board
+   std::shared_ptr<uint32_t> pix_buf(new uint32_t[pix_buf_size]);
+   for (int y = 0; y < rows; y++)
+   {
+      uint32_t* row_slice = &(pix_buf.get()[y * rows * square_area]);
+      uint32_t color = black();
+      if (y % 2 != 0)
+        color = white;
+      for (int x = 0; x < cols * square_area; x++)
+      {
+        if (x % square_side == 0)
+        {
+          if (color == white)
+            color = black();
+          else
+            color = white;
+        }
+
+        row_slice[x] = color;
+      }
+   }
+
+   auto img = image(
+      reinterpret_cast<unsigned char*>(pix_buf.get()),
+      img_fmt::RGBA32,
+      { window_size.x, window_size.y }
+   );
+   cnv.draw(img);
+}
+
+int main(int argc, char const* argv[])
+{
+   return run_app(argc, argv, window_size, colors::white, false);
+}

--- a/examples/image_pixmap_chessboard.cpp
+++ b/examples/image_pixmap_chessboard.cpp
@@ -1,19 +1,11 @@
 /*=============================================================================
-   Copyright (c) 2016-2020 Joel de Guzman
+   Copyright (c) 2016-2020 Brent Soles
 
    Distributed under the MIT License (https://opensource.org/licenses/MIT)
 =============================================================================*/
 #include "app.hpp"
 
 using namespace cycfi::artist;
-
-bool constexpr is_little_endian() {
-   union {
-      uint32_t i;
-      char c[4];
-   } cmp = {0x01020304};
-   return !(cmp.c[0] == 1);
-}
 
 int constexpr rows = 8;
 int constexpr cols = 8;
@@ -25,7 +17,7 @@ size_t constexpr pix_buf_size = rows * cols * square_area;
 
 uint32_t constexpr white = 0xffffffff;
 // on little endian systems RGBA is formatted as ABGR for values
-std::function<uint32_t()> black = []() { return is_little_endian() ? 0xff000000 : 0x000000ff; };
+std::function<uint32_t()> black = []() { return cycfi::is_little_endian() ? 0xff000000 : 0x000000ff; };
 
 auto constexpr window_size = extent{
    static_cast<float>(cols * square_side),

--- a/lib/impl/skia/image.cpp
+++ b/lib/impl/skia/image.cpp
@@ -16,10 +16,24 @@
 
 #include "opaque.hpp"
 #include <stdexcept>
+#include <map>
 #include <string>
+#include <utility> // std::pair
+#include <iostream>
+
+using std::map;
+using std::pair;
 
 namespace cycfi::artist
 {
+   static const map<img_fmt, pair<SkAlphaType, SkColorType>> _img_fmt_map_to_api_type = {
+      {img_fmt::INVALID, {SkAlphaType::kUnknown_SkAlphaType, SkColorType::kUnknown_SkColorType}},
+      {img_fmt::GRAY8, {SkAlphaType::kOpaque_SkAlphaType, SkColorType::kGray_8_SkColorType}},
+      {img_fmt::RGB16, {SkAlphaType::kOpaque_SkAlphaType, SkColorType::kRGB_565_SkColorType}},
+      {img_fmt::RGB32, {SkAlphaType::kOpaque_SkAlphaType, SkColorType::kRGB_888x_SkColorType}},
+      {img_fmt::RGBA32, {SkAlphaType::kOpaque_SkAlphaType, SkColorType::kRGBA_8888_SkColorType}}
+   };
+
    image::image(extent size)
     : _impl{ new artist::image_impl(size) }
    {}
@@ -45,6 +59,28 @@ namespace cycfi::artist
 
       if (codec->getPixels(info, bitmap.getPixels(), bitmap.rowBytes()) != SkCodec::kSuccess)
          fail();
+   }
+
+   image::image(uint8_t* data, img_fmt fmt, extent size)
+    : _impl{ new artist::image_impl(SkBitmap{}) }
+   {
+      if (fmt == img_fmt::INVALID)
+         throw std::runtime_error{ "Error: Cannot initalize format: INVALID" };
+
+      SkAlphaType alpha_fmt;
+      SkColorType byte_fmt;
+      try {
+         std::tie(alpha_fmt, byte_fmt) = _img_fmt_map_to_api_type.at(fmt);
+      } catch(std::exception& /* e */) {
+         throw std::runtime_error{ "Error: unrecognized format." };
+      }
+
+      auto& bitmap = std::get<SkBitmap>(*_impl);
+      SkImageInfo skImgInfo = SkImageInfo::Make(size.x, size.y, byte_fmt, alpha_fmt);
+      if (!bitmap.tryAllocPixels(skImgInfo))
+         throw std::runtime_error{ "Error: Failed to initialize image from pixel buffer" };
+      
+      memcpy(bitmap.getPixels(), data, _pixmap_size(fmt, size));
    }
 
    image::~image()
@@ -169,6 +205,24 @@ namespace cycfi::artist
          };
 
       return std::visit(get_size, _impl->base());
+   }
+
+   size_t image::_pixmap_size(img_fmt fmt, extent size)
+   {
+      size_t fmt_bytes_per_pixel = ([&fmt]() {
+         switch (fmt) {
+            case img_fmt::GRAY8:
+               return 1;
+            case img_fmt::RGB16:
+               return 2;
+            case img_fmt::RGB32:
+            case img_fmt::RGBA32:
+               return 4;
+            default:
+               return 0;
+         }
+      })();
+      return static_cast<size_t>(size.x) * static_cast<size_t>(size.y) * fmt_bytes_per_pixel;
    }
 
    struct offscreen_image::state

--- a/lib/impl/skia/image.cpp
+++ b/lib/impl/skia/image.cpp
@@ -26,13 +26,22 @@ using std::pair;
 
 namespace cycfi::artist
 {
-   static const map<img_fmt, pair<SkAlphaType, SkColorType>> _img_fmt_map_to_api_type = {
-      {img_fmt::INVALID, {SkAlphaType::kUnknown_SkAlphaType, SkColorType::kUnknown_SkColorType}},
-      {img_fmt::GRAY8, {SkAlphaType::kOpaque_SkAlphaType, SkColorType::kGray_8_SkColorType}},
-      {img_fmt::RGB16, {SkAlphaType::kOpaque_SkAlphaType, SkColorType::kRGB_565_SkColorType}},
-      {img_fmt::RGB32, {SkAlphaType::kOpaque_SkAlphaType, SkColorType::kRGB_888x_SkColorType}},
-      {img_fmt::RGBA32, {SkAlphaType::kOpaque_SkAlphaType, SkColorType::kRGBA_8888_SkColorType}}
-   };
+   pair<SkAlphaType, SkColorType> _map_img_fmt_to_api_type(const img_fmt& fmt)
+   {
+      switch(fmt)
+      {
+         case img_fmt::GRAY8:
+            return {SkAlphaType::kOpaque_SkAlphaType, SkColorType::kGray_8_SkColorType};
+         case img_fmt::RGB16:
+            return {SkAlphaType::kOpaque_SkAlphaType, SkColorType::kRGB_565_SkColorType};
+         case img_fmt::RGB32:
+            return {SkAlphaType::kOpaque_SkAlphaType, SkColorType::kRGB_888x_SkColorType};
+         case img_fmt::RGBA32:
+            return {SkAlphaType::kOpaque_SkAlphaType, SkColorType::kRGBA_8888_SkColorType};
+         default:
+            return {SkAlphaType::kUnknown_SkAlphaType, SkColorType::kUnknown_SkColorType};
+      }
+   }
 
    image::image(extent size)
     : _impl{ new artist::image_impl(size) }
@@ -70,7 +79,7 @@ namespace cycfi::artist
       SkAlphaType alpha_fmt;
       SkColorType byte_fmt;
       try {
-         std::tie(alpha_fmt, byte_fmt) = _img_fmt_map_to_api_type.at(fmt);
+         std::tie(alpha_fmt, byte_fmt) = _map_img_fmt_to_api_type(fmt);
       } catch(std::exception& /* e */) {
          throw std::runtime_error{ "Error: unrecognized format." };
       }

--- a/lib/include/artist/image.hpp
+++ b/lib/include/artist/image.hpp
@@ -9,6 +9,7 @@
 #include <artist/point.hpp>
 #include <artist/resources.hpp>
 #include <string_view>
+#include <cstdint>
 #include <memory>
 
 #if defined(ARTIST_SKIA)
@@ -25,6 +26,14 @@ namespace cycfi::artist
    class image_impl;
    using image_impl_ptr = image_impl*;
 
+   enum class img_fmt {
+      INVALID = -1,
+      GRAY8,
+      RGB16,
+      RGB32,            // First byte is Alpha of 1, or ignored
+      RGBA32,           
+   };
+
    ////////////////////////////////////////////////////////////////////////////
    // picture
    ////////////////////////////////////////////////////////////////////////////
@@ -35,6 +44,7 @@ namespace cycfi::artist
       explicit          image(float sizex, float sizey);
       explicit          image(extent size);
       explicit          image(fs::path const& path_);
+      explicit          image(uint8_t* data, img_fmt fmt, extent size);
                         image(image const& rhs) = delete;
                         image(image&& rhs) noexcept;
                         ~image();
@@ -51,6 +61,7 @@ namespace cycfi::artist
       extent            bitmap_size() const;
 
    private:
+      size_t            _pixmap_size(img_fmt, extent size);
 
       image_impl_ptr  _impl;
    };


### PR DESCRIPTION
Pixel buffer support has been added for the Skia backend.

By default, the memory for the image is copied over to be managed
by the SkBitmap instance within the image. This is to give the caller
safety when using a raw pointer after creating an image.