### PR TITLE
Swap print_elapsed font on apple devices

### DIFF
--- a/examples/print_elapsed.cpp
+++ b/examples/print_elapsed.cpp
@@ -29,8 +29,12 @@ struct exp_moving_average
 
 void print_elapsed(canvas& cnv, point br, color bkd, color c)
 {
-   static font open_sans = font_descr{ "Open Sans", 12 };
-   static auto metrics = open_sans.metrics();
+#if defined(__APPLE__)
+   static font text_font = font_descr{ "Lucida Grande", 12 };
+#else
+   static font text_font = font_descr{ "Open Sans", 12 };
+#endif
+   static auto metrics = text_font.metrics();
    static auto height = metrics.ascent + metrics.leading + metrics.descent;
    static exp_moving_average<256> ma;
    static int refresh = 0;
@@ -44,13 +48,13 @@ void print_elapsed(canvas& cnv, point br, color bkd, color c)
       fps_str = std::to_string(1/ave) + " fps";
    }
 
-   auto width = open_sans.measure_text(fps_str);
+   auto width = text_font.measure_text(fps_str);
    cnv.fill_style(bkd);
    cnv.add_rect({ br.x - (width + 4), br.y - height, br.x, br.y });
    cnv.fill();
 
    cnv.fill_style(c);
-   cnv.font(open_sans);
+   cnv.font(text_font);
    cnv.text_align(cnv.right | cnv.bottom);
    cnv.fill_text(fps_str, { br.x-2, br.y });
 }


### PR DESCRIPTION
I noticed that some of the examples (rain, space, etc.) were broken when compiled on macos. They crash with a fairly cryptic error. This was caused by a null pointer in the print_elapsed function. I replaced the font used to match the typography example and everything started to work.