### PR TITLE
Various font cache fixes

### DIFF
--- a/lib/impl/skia/font.cpp
+++ b/lib/impl/skia/font.cpp
@@ -132,16 +132,16 @@ namespace cycfi::artist
       void init_font_map()
       {
          FcInit();
-         auto config = fc_config_ptr{ FcConfigCreate() };
+         FcConfig* config = FcConfigGetCurrent();
          auto user_fonts_path = get_user_fonts_directory();
-         FcConfigAppFontAddDir(config.get(), (FcChar8 const*)user_fonts_path.string().c_str());
+         FcConfigAppFontAddDir(config, (FcChar8 const*)user_fonts_path.string().c_str());
          auto pat = fc_patern_ptr{ FcPatternCreate() };
          auto os = fc_object_set_ptr{
                      FcObjectSetBuild(
                         FC_FAMILY, FC_FULLNAME, FC_WIDTH, FC_WEIGHT
                       , FC_SLANT, FC_FILE, FC_INDEX, nullptr)
                      };
-         auto fs = fc_font_set_ptr{ FcFontList(config.get(), pat.get(), os.get()) };
+         auto fs = fc_font_set_ptr{ FcFontList(config, pat.get(), os.get()) };
 
          for (int i=0; fs && i < fs->nfont; ++i)
          {


### PR DESCRIPTION
Background: my demo program was running at a glorious 0.5-2FPS, which as it turns out was because Artist was running `SkTypeface::MakeFromName` *every frame*. This apparently happened because my system doesn't have Open Sans, thus no font would ever be found in the cache. The fact that I have over 400 fonts installed generally didn't help the situation!

There were two core issues:
- System fonts are never included in the cache, so the majority of my 400+ fonts would have to be loaded every frame regardless.
- The fallback font path always reads its typefaces from disk rather than being able to check the cache. This was changed so that there's a special cached "family" specifically for the fallback typeface, which allows its different metric combinations to all be cached.

The individual commits have more descriptions of the methodology in their messages.