### PR TITLE
Handle extreme radii in add_round_rect

### DIFF
--- a/lib/impl/macos/quartz2d/canvas.mm
+++ b/lib/impl/macos/quartz2d/canvas.mm
@@ -526,14 +526,6 @@ namespace cycfi::artist
       CGContextAddRect(CGContextRef(_context), CGRectMake(r.left, r.top, r.width(), r.height()));
    }
 
-   void canvas::add_round_rect(const rect& r, float radius)
-   {
-      if (radius > 0.0f)
-         detail::round_rect(*this, r, radius);
-      else
-         add_rect(r);
-   }
-
    void canvas::add_path(path const& p)
    {
       CGContextAddPath(CGContextRef(_context), p.impl());
@@ -985,4 +977,13 @@ namespace cycfi::artist
          hints          :  nil
       ];
    }
+
+   void canvas::add_round_rect_impl(const rect& r, float radius)
+   {
+      if (radius > 0.0f)
+         detail::round_rect(*this, r, radius);
+      else
+         add_rect(r);
+   }
+
 }

--- a/lib/impl/macos/quartz2d/path.mm
+++ b/lib/impl/macos/quartz2d/path.mm
@@ -89,14 +89,6 @@ namespace cycfi::artist
       );
    }
 
-   void path::add_round_rect(rect const& r, float radius)
-   {
-      CGPathAddRoundedRect(_impl, nullptr,
-         CGRect{ { r.left, r.top }, { r.width(), r.height() } }
-       , radius, radius
-      );
-   }
-
    void path::move_to(point p)
    {
       CGPathMoveToPoint(_impl, nullptr, p.x, p.y);
@@ -140,4 +132,13 @@ namespace cycfi::artist
    {
       CGPathAddCurveToPoint(_impl, nullptr, cp1.x, cp1.y, cp2.x, cp2.y, end.x, end.y);
    }
+
+   void path::add_round_rect_impl(rect const& r, float radius)
+   {
+      CGPathAddRoundedRect(_impl, nullptr,
+         CGRect{ { r.left, r.top }, { r.width(), r.height() } }
+       , radius, radius
+      );
+   }
+
 }

--- a/lib/impl/skia/canvas.cpp
+++ b/lib/impl/skia/canvas.cpp
@@ -318,11 +318,6 @@ namespace cycfi::artist
       _state->path().addRect({ r.left, r.top, r.right, r.bottom });
    }
 
-   void canvas::add_round_rect(rect const& r, float radius)
-   {
-      _state->path().addRoundRect({ r.left, r.top, r.right, r.bottom }, radius, radius);
-   }
-
    void canvas::add_circle(circle const& c)
    {
       _state->path().addCircle(c.cx, c.cy, c.radius);
@@ -654,4 +649,10 @@ namespace cycfi::artist
 
       return std::visit(draw_picture, pic.impl()->base());
    }
+
+   void canvas::add_round_rect_impl(rect const& r, float radius)
+   {
+      _state->path().addRoundRect({ r.left, r.top, r.right, r.bottom }, radius, radius);
+   }
+
 }

--- a/lib/impl/skia/path.cpp
+++ b/lib/impl/skia/path.cpp
@@ -82,11 +82,6 @@ namespace cycfi::artist
       _impl->addRect({ r.left, r.top, r.right, r.bottom });
    }
 
-   void path::add_round_rect(rect const& r, float radius)
-   {
-      _impl->addRoundRect({ r.left, r.top, r.right, r.bottom }, radius, radius);
-   }
-
    void path::add_circle(circle const& c)
    {
       _impl->addCircle(c.cx, c.cy, c.radius);
@@ -136,4 +131,10 @@ namespace cycfi::artist
    {
       _impl->setFillType(rule == fill_winding? SkPathFillType::kWinding : SkPathFillType::kEvenOdd);
    }
+
+   void path::add_round_rect_impl(rect const& r, float radius)
+   {
+      _impl->addRoundRect({ r.left, r.top, r.right, r.bottom }, radius, radius);
+   }
+
 }

--- a/lib/include/artist/canvas.hpp
+++ b/lib/include/artist/canvas.hpp
@@ -355,6 +355,8 @@ namespace cycfi::artist
 
       canvas_impl*      _context;
       canvas_state_ptr  _state;
+
+      void              add_round_rect_impl(const rect& r, float radius);
    };
 }
 

--- a/lib/include/artist/detail/canvas_impl.hpp
+++ b/lib/include/artist/detail/canvas_impl.hpp
@@ -6,6 +6,8 @@
 #if !defined(ARTIST_DETAIL_CANVAS_IMPL_MAY_3_2016)
 #define ARTIST_DETAIL_CANVAS_IMPL_MAY_3_2016
 
+#include <algorithm>
+
 namespace cycfi::artist
 {
    ////////////////////////////////////////////////////////////////////////////
@@ -85,6 +87,12 @@ namespace cycfi::artist
    inline void canvas::add_rect(float x, float y, float width, float height)
    {
       add_rect({ x, y, extent{ width, height } });
+   }
+
+   inline void canvas::add_round_rect(const rect& r, float radius)
+   {
+      radius = std::clamp(radius, 0.0f, std::min(r.width(), r.height()) / 2);
+      add_round_rect_impl(r, radius);
    }
 
    inline void canvas::add_round_rect(

--- a/lib/include/artist/path.hpp
+++ b/lib/include/artist/path.hpp
@@ -9,6 +9,7 @@
 #include <infra/support.hpp>
 #include <artist/rect.hpp>
 #include <artist/circle.hpp>
+#include <algorithm>
 #include <string_view>
 #include <cmath>
 
@@ -108,6 +109,8 @@ namespace cycfi::artist
 
       path_impl*        _impl;
 
+      void              add_round_rect_impl(rect const& r, float radius);
+
 #if defined(ARTIST_QUARTZ_2D)
       fill_rule_enum    _fill_rule = fill_winding;
 #endif
@@ -142,6 +145,12 @@ namespace cycfi::artist
    inline bool path::includes(float x, float y) const
    {
       return includes({ x, y });
+   }
+
+   inline void path::add_round_rect(rect const& r, float radius)
+   {
+      radius = std::clamp(radius, 0.0f, std::min(r.width(), r.height()) / 2);
+      add_round_rect_impl(r, radius);
    }
 
    inline void path::add_rect(float x, float y, float width, float height)


### PR DESCRIPTION
Warning: I've been unable to test that this builds or has the desired effect, as I'm getting a stubborn and nonsensical build error from Visual Studio 2022 failing to copy dlls. I apologise for this, and aim to fix that when I get chance so that in future I can test these things myself!

This originated as a follow on from a fix to cycfi/elements. We wish to
ensure that the radius for a round rectangle does not exceed half of the
minimum dimension of the rectangle. I have chosen to introduce the
method `add_round_rect_impl` to both `canvas` and `path` so that
regardless of the backend, we get consistent behaviour when the radius
is too large.

Note: I believe the implementation in skia would have given this result
already, but to me it seems preferable to control this instead of
allowing implementation-defined behaviour.