### PR TITLE
Fix a warning in the examples

### DIFF
--- a/examples/composite_ops.cpp
+++ b/examples/composite_ops.cpp
@@ -45,6 +45,7 @@ char const* mode_name(canvas::composite_op_enum mode)
       case canvas::color_op:          return "color_op";
       case canvas::luminosity:        return "luminosity";
    };
+   return "";
 }
 
 image dest{"dest.png" };


### PR DESCRIPTION
Not all paths in this function returned a value.