### PR TITLE
Use CoreGraphics affine transform for canvas and fix some memory leaks

### DIFF
--- a/lib/impl/macos/quartz2d/font.mm
+++ b/lib/impl/macos/quartz2d/font.mm
@@ -74,19 +74,17 @@ namespace cycfi::artist
 
          if (font)
          {
-            _ptr = (__bridge font_impl_ptr) font;
-            CFRetain(_ptr);
+            _ptr = (__bridge_retained font_impl_ptr) font;
             break;
          }
       }
       if (_ptr == nullptr)
       {
-         _ptr = (__bridge font_impl_ptr)
+         _ptr = (__bridge_retained font_impl_ptr)
             [NSFont
                systemFontOfSize : descr._size
                          weight : weight
             ];
-         CFRetain(_ptr);
       }
    }
 
@@ -139,7 +137,7 @@ namespace cycfi::artist
       NSFont* font = (__bridge NSFont*) _ptr;
       NSDictionary* attr = @{ NSFontAttributeName : font };
       NSString* text = detail::ns_string(str);
-      const CGSize textSize = [text sizeWithAttributes : attr];
+      const auto textSize = [text sizeWithAttributes : attr];
       return textSize.width;
    }
 }

--- a/lib/impl/macos/quartz2d/osx_utils.hpp
+++ b/lib/impl/macos/quartz2d/osx_utils.hpp
@@ -43,7 +43,7 @@ namespace cycfi::artist::detail
 
    inline NSString* ns_string(char const* f, char const* l)
    {
-      return (__bridge NSString*) cf_string(f, l);
+      return (__bridge_transfer NSString*) cf_string(f, l);
    }
 
    inline NSString* ns_string(std::string_view str)

--- a/lib/impl/macos/quartz2d/text_layout.mm
+++ b/lib/impl/macos/quartz2d/text_layout.mm
@@ -192,6 +192,8 @@ namespace cycfi::artist
       last.pos.y += finfo.last_line_height - finfo.line_height;
       last.height = finfo.last_line_height;
       CFRelease(attr_string);
+      CFRelease(typesetter);
+      CFRelease(font_attributes);
    }
 
    void text_layout::impl::draw(canvas& cnv, point p, color c)


### PR DESCRIPTION
This commit fixes a display problem for plugins in Reaper, where the origin of the view in device space {0, 0} is not located at { 0, 0 } in user space.  The previous manual scaling calculations relied on this assumption and therefore resulted in incorrect scaling in Reaper. This PR:

- replaces the internal canvas scaling logic with the equivalent CGAffineTransform, and, for convenience,
- fixes what we observed to be a few small memory leaks.

We've only tested this with macOS Catalina and Monterey, on which display is correct for plugins in Reaper and Ableton Live, and also standalone applications using cycfi::elements::window. 